### PR TITLE
Update MagicMirrorItem.java

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/items/relics/MagicMirrorItem.java
+++ b/src/main/java/it/hurts/sskirillss/relics/items/relics/MagicMirrorItem.java
@@ -58,7 +58,7 @@ public class MagicMirrorItem extends RelicItem {
                                         .build())
                                 .stat(StatData.builder("cooldown")
                                         .icon(StatIcons.COOLDOWN)
-                                        .initialValue(60D, 120D)
+                                        .initialValue(120D, 60D)
                                         .upgradeModifier(UpgradeOperation.MULTIPLY_BASE, -0.05D)
                                         .formatValue(value -> MathUtils.round(value, 1))
                                         .build())


### PR DESCRIPTION
Inverted "initialValues" 60-120 to 120-60 to create an inverse relationship between cooldown statistic and cooldown time (higher stat, lower cooldown)

### Description of Issue:
**Relic:** Magic Mirror
**Ability:** Wormhole / `teleport`
**Statistic:** Recharge / `cooldown`

When the "Recharge" statistic is rolled, a higher stat (say, 5) creates a higher, *longer* recharge time than a lower stat (say, 1). This is likely unintentional. For example, a Level 0, full stat mirror will have a cooldown of 120 seconds, while a Level 0, zero stat mirror will have a *better* cooldown of 60 seconds.

**Expected behavior:** A high stat in Recharge should mean lowest time, and a low stat should mean a higher time, given that recharge time is something which is better at lower values. I have double checked the math in "randomizeStat," and it looks as though this change should fix the issue, creating a total range of 120 seconds for Level 0, 0 stat mirrors, and 0 seconds for Level 10, full stat mirrors.

A big side effect of this issue is how the "Luck" is involved in rerolling the mirror's stats, eventually locking the player out of the lower, "better" stats for cooldown.