### PR TITLE
Fix ReflectiveOrbEntity NBT data

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/entities/ReflectiveOrbEntity.java
+++ b/src/main/java/it/hurts/sskirillss/relics/entities/ReflectiveOrbEntity.java
@@ -287,20 +287,26 @@ public class ReflectiveOrbEntity extends ThrowableProjectile {
 
     @Override
     protected void readAdditionalSaveData(CompoundTag compound) {
+        super.readAdditionalSaveData(compound);
+
         this.setDamage(compound.getFloat("damage"));
         this.setTargeted(compound.getBoolean("targeted"));
         this.setLifetime(compound.getInt("lifetime"));
         this.setPiercings(compound.getInt("piercings"));
         this.setBounces(compound.getInt("bounces"));
+        this.setStun(compound.getFloat("stun"));
     }
 
     @Override
     protected void addAdditionalSaveData(CompoundTag compound) {
+        super.addAdditionalSaveData(compound);
+
         compound.putFloat("damage", this.getDamage());
         compound.putBoolean("targeted", this.isTargeted());
         compound.putInt("lifetime", this.getLifetime());
         compound.putInt("piercings", this.getPiercings());
         compound.putInt("bounces", this.getBounces());
+        compound.putFloat("stun", this.getStun());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure ReflectiveOrbEntity saves and loads stun value
- invoke superclass methods when reading/writing NBT

## Testing
- `sh gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855ae4298f48321874d9b50688a9eff