### PR TITLE
Fix attribute removal on Jellyfish Necklace unequip

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/items/relics/necklace/JellyfishNecklaceItem.java
+++ b/src/main/java/it/hurts/sskirillss/relics/items/relics/necklace/JellyfishNecklaceItem.java
@@ -281,7 +281,7 @@ public class JellyfishNecklaceItem extends RelicItem {
 
         var entity = slotContext.entity();
 
-        EntityUtils.removeAttribute(entity, stack, Attributes.MAX_ABSORPTION, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL);
+        EntityUtils.removeAttribute(entity, stack, Attributes.MAX_ABSORPTION, AttributeModifier.Operation.ADD_VALUE);
         EntityUtils.removeAttribute(entity, stack, Attributes.MAX_HEALTH, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL);
     }
 


### PR DESCRIPTION
## Summary
- tweak attribute removal when unequipping the Jellyfish Necklace

## Testing
- `./gradlew tasks --all` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68570df2519c8321bdf5a5235c9663fa