### PR TITLE
Fix component getters in JellyfishNecklaceItem

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/items/relics/necklace/JellyfishNecklaceItem.java
+++ b/src/main/java/it/hurts/sskirillss/relics/items/relics/necklace/JellyfishNecklaceItem.java
@@ -122,7 +122,7 @@ public class JellyfishNecklaceItem extends RelicItem {
     }
 
     public int getCooldown(ItemStack stack) {
-        return stack.getOrDefault(DataComponentRegistry.JELLYFISH_NECKLACE_COOLDOWN.get(), 0);
+        return stack.getOrDefault(DataComponentRegistry.JELLYFISH_NECKLACE_COOLDOWN, 0);
     }
 
     public void setCooldown(ItemStack stack, int cooldown) {
@@ -134,7 +134,7 @@ public class JellyfishNecklaceItem extends RelicItem {
     }
 
     public int getDuration(ItemStack stack) {
-        return stack.getOrDefault(DataComponentRegistry.JELLYFISH_NECKLACE_DURATION.get(), 0);
+        return stack.getOrDefault(DataComponentRegistry.JELLYFISH_NECKLACE_DURATION, 0);
     }
 
     public void setDuration(ItemStack stack, int duration) {


### PR DESCRIPTION
## Summary
- remove stray `get()` calls in JellyfishNecklace component accessors

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68570df5ae1c832183aae76120f05bf2