### PR TITLE
[1.20.1] Improve performance of RelicLootModifier.

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/level/RelicLootModifier.java
+++ b/src/main/java/it/hurts/sskirillss/relics/level/RelicLootModifier.java
@@ -5,7 +5,9 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.hurts.sskirillss.relics.init.LootCodecRegistry;
 import it.hurts.sskirillss.relics.items.relics.base.IRelicItem;
 import it.hurts.sskirillss.relics.items.relics.base.data.RelicStorage;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
@@ -15,9 +17,14 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public class RelicLootModifier extends LootModifier {
+    private static final Set<String> INVALID_PATTERN_CACHE = new ObjectOpenHashSet<>();
+    private static final Map<String, Pattern> COMPILED_PATTERN_CACHE = new Object2ObjectOpenHashMap<>();
+
     public static final Codec<RelicLootModifier> CODEC = RecordCodecBuilder.create(inst -> codecStart(inst).apply(inst, RelicLootModifier::new));
 
     public RelicLootModifier(LootItemCondition[] conditionsIn) {
@@ -36,9 +43,23 @@ public class RelicLootModifier extends LootModifier {
                 String pattern = entry.getKey();
                 float chance = entry.getValue();
 
-                try {
-                    isValid = lootId.matches(pattern);
-                } catch (PatternSyntaxException exception) {
+                if (!INVALID_PATTERN_CACHE.contains(pattern)) {
+                    Pattern compiledPattern = COMPILED_PATTERN_CACHE.get(pattern);
+                    if (compiledPattern == null) {
+                        try {
+                            compiledPattern = Pattern.compile(pattern);
+                        } catch (PatternSyntaxException ignored) {
+                        }
+                    }
+                    if (compiledPattern != null) {
+                        COMPILED_PATTERN_CACHE.put(pattern, compiledPattern);
+                        var matcher = compiledPattern.matcher(lootId);
+                        isValid = matcher.matches();
+                    } else {
+                        INVALID_PATTERN_CACHE.add(pattern);
+                        isValid = lootId.equals(pattern);
+                    }
+                } else {
                     isValid = lootId.equals(pattern);
                 }
 


### PR DESCRIPTION
The String's "matches" function repeatedly compiles, without caching, the pattern variable, which can end up consuming a large amount of the tick.

By implementing an actual internal cache, this dramatically reduces tick usage, especially on servers with heavy block-break automation, where global loot modifiers are constantly being applied.