### PR TITLE
Fix NPE in CurioSlotReference when Curio slot type is not registered

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/system/casts/slots/CurioSlotReference.java
+++ b/src/main/java/it/hurts/sskirillss/relics/system/casts/slots/CurioSlotReference.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
 @Data
@@ -21,7 +22,12 @@ public class CurioSlotReference extends SlotReference {
     @Override
     public ItemStack gatherStack(Player player) {
         return CuriosApi.getCuriosInventory(player).map(itemHandler -> {
-            IDynamicStackHandler stackHandler = itemHandler.getCurios().get(getType()).getStacks();
+            ICurioStacksHandler curioHandler = itemHandler.getCurios().get(getType());
+
+            if (curioHandler == null)
+                return ItemStack.EMPTY;
+
+            IDynamicStackHandler stackHandler = curioHandler.getStacks();
 
             int index = getIndex();
 


### PR DESCRIPTION
**Bug:** `CurioSlotReference.gatherStack()` can throw a `NullPointerException` crashing the client.

**Cause:** `itemHandler.getCurios().get(getType())` returns `null` when a slot type is not yet registered in the Curios handler. This was observed when using Accessories with the Accessories Compatibility Layer, where a slot may exist in Accessories before it has been brdiged into Curios. If Relics' tick handler runs during this window it crashes.

**Reproduction:** Observed when using Relics alongside Accessories and Accessories Compatibility Layer. Re-equipping the offending item resolved it, suggesting it is a timing/registration issue rather than a persistent state.

**Fix:** Added a null check on the result of `getCurios().get(getType())`. If null, `ItemStack.EMPTY` is returned.
 