### PR TITLE
perf: better map codec for keys with expensive Object#equals impls

### DIFF
--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/AbilityStatisticComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/AbilityStatisticComponent.java
@@ -2,11 +2,8 @@ package it.hurts.sskirillss.relics.api.relics;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Singular;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
+import lombok.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +20,7 @@ public class AbilityStatisticComponent {
 
     public static final Codec<AbilityStatisticComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    Codec.unboundedMap(Codec.STRING, AbilityMetricComponent.CODEC)
+                    RelicsCodecs.unboundedMap(Codec.STRING, AbilityMetricComponent.CODEC)
                             .optionalFieldOf("metrics", new HashMap<>())
                             .forGetter(AbilityStatisticComponent::getMetrics)
             ).apply(instance, AbilityStatisticComponent::new)

--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/PlayerResearchComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/PlayerResearchComponent.java
@@ -2,6 +2,7 @@ package it.hurts.sskirillss.relics.api.relics;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -21,7 +22,7 @@ public class PlayerResearchComponent {
 
     public static final Codec<PlayerResearchComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    Codec.unboundedMap(Codec.STRING, ResearchComponent.CODEC)
+                    RelicsCodecs.unboundedMap(Codec.STRING, ResearchComponent.CODEC)
                             .optionalFieldOf("research", Map.of())
                             .forGetter(PlayerResearchComponent::getResearch)
             ).apply(instance, PlayerResearchComponent::new)

--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/RelicStatisticComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/RelicStatisticComponent.java
@@ -2,11 +2,8 @@ package it.hurts.sskirillss.relics.api.relics;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Singular;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
+import lombok.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +20,7 @@ public class RelicStatisticComponent {
 
     public static final Codec<RelicStatisticComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    Codec.unboundedMap(Codec.STRING, RelicMetricComponent.CODEC)
+                    RelicsCodecs.unboundedMap(Codec.STRING, RelicMetricComponent.CODEC)
                             .optionalFieldOf("metrics", new HashMap<>())
                             .forGetter(RelicStatisticComponent::getMetrics)
             ).apply(instance, RelicStatisticComponent::new)

--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/ResearchComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/ResearchComponent.java
@@ -2,6 +2,7 @@ package it.hurts.sskirillss.relics.api.relics;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -23,7 +24,7 @@ public class ResearchComponent {
 
     public static final Codec<ResearchComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    Codec.unboundedMap(Codec.STRING, Codec.list(Codec.INT))
+                    RelicsCodecs.unboundedMap(Codec.STRING, Codec.list(Codec.INT))
                             .fieldOf("links")
                             .forGetter(ResearchComponent::getLinks),
                     Codec.BOOL

--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/abilities/AbilitiesComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/abilities/AbilitiesComponent.java
@@ -3,11 +3,8 @@ package it.hurts.sskirillss.relics.api.relics.abilities;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.hurts.sskirillss.relics.api.relics.synergies.SynergyComponent;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Singular;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
+import lombok.*;
 
 import java.util.Map;
 
@@ -25,10 +22,10 @@ public class AbilitiesComponent {
 
     public static final Codec<AbilitiesComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    Codec.unboundedMap(Codec.STRING, AbilityComponent.CODEC)
+                    RelicsCodecs.unboundedMap(Codec.STRING, AbilityComponent.CODEC)
                             .fieldOf("abilities")
                             .forGetter(AbilitiesComponent::getAbilities),
-                    Codec.unboundedMap(Codec.STRING, SynergyComponent.CODEC)
+                    RelicsCodecs.unboundedMap(Codec.STRING, SynergyComponent.CODEC)
                             .fieldOf("synergies")
                             .forGetter(AbilitiesComponent::getSynergies)
             ).apply(instance, AbilitiesComponent::new)

--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/abilities/AbilityComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/abilities/AbilityComponent.java
@@ -2,16 +2,13 @@ package it.hurts.sskirillss.relics.api.relics.abilities;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.hurts.sskirillss.relics.api.relics.AbilityStatisticComponent;
 import it.hurts.sskirillss.relics.api.relics.LockComponent;
 import it.hurts.sskirillss.relics.api.relics.RankModifierComponent;
-import it.hurts.sskirillss.relics.api.relics.AbilityStatisticComponent;
 import it.hurts.sskirillss.relics.api.relics.abilities.activation.AbilityActivationComponent;
 import it.hurts.sskirillss.relics.api.relics.abilities.stats.StatComponent;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Singular;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
+import lombok.*;
 
 import java.util.Map;
 
@@ -34,11 +31,11 @@ public class AbilityComponent {
 
     public static final Codec<AbilityComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    Codec.unboundedMap(Codec.STRING, StatComponent.CODEC).fieldOf("stats").forGetter(AbilityComponent::getStats),
+                    RelicsCodecs.unboundedMap(Codec.STRING, StatComponent.CODEC).fieldOf("stats").forGetter(AbilityComponent::getStats),
                     LockComponent.CODEC.fieldOf("lock").forGetter(AbilityComponent::getLock),
                     AbilityStatisticComponent.CODEC.optionalFieldOf("statistic", AbilityStatisticComponent.EMPTY).forGetter(AbilityComponent::getStatistic),
                     Codec.STRING.optionalFieldOf("mode", "").forGetter(AbilityComponent::getMode),
-                    Codec.unboundedMap(Codec.STRING, RankModifierComponent.CODEC).optionalFieldOf("rank_modifiers", Map.of()).forGetter(AbilityComponent::getRankModifiers),
+                    RelicsCodecs.unboundedMap(Codec.STRING, RankModifierComponent.CODEC).optionalFieldOf("rank_modifiers", Map.of()).forGetter(AbilityComponent::getRankModifiers),
                     AbilityActivationComponent.CODEC.optionalFieldOf("activation", AbilityActivationComponent.EMPTY).forGetter(AbilityComponent::getActivation),
                     Codec.INT.fieldOf("points").forGetter(AbilityComponent::getPoints)
             ).apply(instance, AbilityComponent::new)

--- a/src/main/java/it/hurts/sskirillss/relics/api/relics/synergies/SynergyComponent.java
+++ b/src/main/java/it/hurts/sskirillss/relics/api/relics/synergies/SynergyComponent.java
@@ -3,11 +3,8 @@ package it.hurts.sskirillss.relics.api.relics.synergies;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.hurts.sskirillss.relics.api.relics.RankModifierComponent;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Singular;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
+import lombok.*;
 
 import java.util.Map;
 
@@ -25,7 +22,7 @@ public class SynergyComponent {
     public static final Codec<SynergyComponent> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
                     Codec.STRING.optionalFieldOf("mode", "").forGetter(SynergyComponent::getMode),
-                    Codec.unboundedMap(Codec.STRING, RankModifierComponent.CODEC).optionalFieldOf("rank_modifiers", Map.of()).forGetter(SynergyComponent::getRankModifiers)
+                    RelicsCodecs.unboundedMap(Codec.STRING, RankModifierComponent.CODEC).optionalFieldOf("rank_modifiers", Map.of()).forGetter(SynergyComponent::getRankModifiers)
             ).apply(instance, SynergyComponent::new)
     );
 }

--- a/src/main/java/it/hurts/sskirillss/relics/init/RelicsDataComponents.java
+++ b/src/main/java/it/hurts/sskirillss/relics/init/RelicsDataComponents.java
@@ -11,6 +11,7 @@ import it.hurts.sskirillss.relics.items.relics.SphereOfSelfSacrifice;
 import it.hurts.sskirillss.relics.items.relics.back.GhostlyMantleItem;
 import it.hurts.sskirillss.relics.items.relics.feet.CutGlassBootItem;
 import it.hurts.sskirillss.relics.items.relics.ring.RingOfTheSevenDeadlySinsItem;
+import it.hurts.sskirillss.relics.utils.RelicsCodecs;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.phys.Vec3;
@@ -34,7 +35,7 @@ public class RelicsDataComponents {
                     .build()
     );
 
-    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Map<String, CutGlassBootItem.FluidEntry>>> CUT_GLASS_BOOT_FLUIDS = RelicsDataComponents.construct("cut_glass_boot/fluids", Codec.unboundedMap(Codec.STRING, CutGlassBootItem.FluidEntry.CODEC));
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Map<String, CutGlassBootItem.FluidEntry>>> CUT_GLASS_BOOT_FLUIDS = RelicsDataComponents.construct("cut_glass_boot/fluids", RelicsCodecs.unboundedMap(Codec.STRING, CutGlassBootItem.FluidEntry.CODEC));
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> CUT_GLASS_BOOT_SELECTED_FLUID_INDEX = RelicsDataComponents.construct("cut_glass_boot/selected_fluid_index", Codec.INT);
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Float>> CUT_GLASS_BOOT_SPEED_BLEND = RelicsDataComponents.construct("cut_glass_boot/speed_blend", Codec.FLOAT);
 
@@ -68,9 +69,9 @@ public class RelicsDataComponents {
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> GLITCHY_MANTLE_ILLUSION_COOLDOWN = RelicsDataComponents.construct("glitchy_mantle/illusion_cooldown", Codec.INT);
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Vec3>> GHOSTLY_MANTLE_LAST_FOG_POS = RelicsDataComponents.construct("ghostly_mantle/last_fog_pos", Vec3.CODEC);
-    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Map<String, GhostlyMantleItem.GazeChargeData>>> GHOSTLY_MANTLE_GAZE_CHARGES = RelicsDataComponents.construct("ghostly_mantle/gaze_charges", Codec.unboundedMap(Codec.STRING, GhostlyMantleItem.GazeChargeData.CODEC));
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Map<String, GhostlyMantleItem.GazeChargeData>>> GHOSTLY_MANTLE_GAZE_CHARGES = RelicsDataComponents.construct("ghostly_mantle/gaze_charges", RelicsCodecs.unboundedMap(Codec.STRING, GhostlyMantleItem.GazeChargeData.CODEC));
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> GHOSTLY_MANTLE_ESCAPE_COOLDOWN = RelicsDataComponents.construct("ghostly_mantle/escape_cooldown", Codec.INT);
-    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Map<String, Double>>> GHOSTLY_MANTLE_REPRISAL_MARKS = RelicsDataComponents.construct("ghostly_mantle/reprisal_marks", Codec.unboundedMap(Codec.STRING, Codec.DOUBLE));
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<Map<String, Double>>> GHOSTLY_MANTLE_REPRISAL_MARKS = RelicsDataComponents.construct("ghostly_mantle/reprisal_marks", RelicsCodecs.unboundedMap(Codec.STRING, Codec.DOUBLE));
 
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> ROLLER_SKATE_DURATION = RelicsDataComponents.construct("roller_skate/duration", Codec.INT);
 

--- a/src/main/java/it/hurts/sskirillss/relics/utils/RelicsCodecs.java
+++ b/src/main/java/it/hurts/sskirillss/relics/utils/RelicsCodecs.java
@@ -2,10 +2,14 @@ package it.hurts.sskirillss.relics.utils;
 
 import com.mojang.datafixers.util.Pair;
 import com.mojang.datafixers.util.Unit;
-import com.mojang.serialization.*;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.Lifecycle;
+import com.mojang.serialization.MapLike;
 import com.mojang.serialization.codecs.BaseMapCodec;
-import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -45,7 +49,7 @@ public class RelicsCodecs {
 
         @Override
         public <T> DataResult<Map<K, V>> decode(final DynamicOps<T> ops, final MapLike<T> input) {
-            final Object2ObjectMap<K, V> read = new Object2ObjectArrayMap<>();
+            final Object2ObjectMap<K, V> read = new Object2ObjectOpenHashMap<>();
             final Stream.Builder<Pair<T, T>> failed = Stream.builder();
 
             final DataResult<Unit> result = input.entries().reduce(

--- a/src/main/java/it/hurts/sskirillss/relics/utils/RelicsCodecs.java
+++ b/src/main/java/it/hurts/sskirillss/relics/utils/RelicsCodecs.java
@@ -1,0 +1,85 @@
+package it.hurts.sskirillss.relics.utils;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.datafixers.util.Unit;
+import com.mojang.serialization.*;
+import com.mojang.serialization.codecs.BaseMapCodec;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class RelicsCodecs {
+    /**
+     * A copy of {@link com.mojang.serialization.codecs.UnboundedMapCodec} that wraps the result with
+     * {@link Collections#unmodifiableMap(Map)} instead of copying into a {@link com.google.common.collect.ImmutableMap}
+     * to boost performance for keys with expensive {@link Object#equals(Object)} implementations like {@link String}.
+     *
+     * @param keyCodec The codec to use for de/serializing the keys
+     * @param elementCodec The codec to use for de/serializing the elements
+     * @param <K> The type of the keys
+     * @param <V> The type of the elements
+     */
+    public record RelicsUnboundedMapCodec<K, V>(
+            Codec<K> keyCodec,
+            Codec<V> elementCodec
+    ) implements BaseMapCodec<K, V>, Codec<Map<K, V>> {
+        @Override
+        public <T> DataResult<Pair<Map<K, V>, T>> decode(final DynamicOps<T> ops, final T input) {
+            return ops.getMap(input).setLifecycle(Lifecycle.stable()).flatMap(map -> decode(ops, map)).map(r -> Pair.of(r, input));
+        }
+
+        @Override
+        public <T> DataResult<T> encode(final Map<K, V> input, final DynamicOps<T> ops, final T prefix) {
+            return encode(input, ops, ops.mapBuilder()).build(prefix);
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return "RelicsUnboundedMapCodec[" + keyCodec + " -> " + elementCodec + ']';
+        }
+
+        @Override
+        public <T> DataResult<Map<K, V>> decode(final DynamicOps<T> ops, final MapLike<T> input) {
+            final Object2ObjectMap<K, V> read = new Object2ObjectArrayMap<>();
+            final Stream.Builder<Pair<T, T>> failed = Stream.builder();
+
+            final DataResult<Unit> result = input.entries().reduce(
+                    DataResult.success(Unit.INSTANCE, Lifecycle.stable()),
+                    (r, pair) -> {
+                        final DataResult<K> key = keyCodec().parse(ops, pair.getFirst());
+                        final DataResult<V> value = elementCodec().parse(ops, pair.getSecond());
+
+                        final DataResult<Pair<K, V>> entryResult = key.apply2stable(Pair::of, value);
+                        final Optional<Pair<K, V>> entry = entryResult.resultOrPartial();
+                        if (entry.isPresent()) {
+                            final V existingValue = read.putIfAbsent(entry.get().getFirst(), entry.get().getSecond());
+                            if (existingValue != null) {
+                                failed.add(pair);
+                                return r.apply2stable((u, p) -> u, DataResult.error(() -> "Duplicate entry for key: '" + entry.get().getFirst() + "'"));
+                            }
+                        }
+                        if (entryResult.isError()) {
+                            failed.add(pair);
+                        }
+
+                        return r.apply2stable((u, p) -> u, entryResult);
+                    },
+                    (r1, r2) -> r1.apply2stable((u1, u2) -> u1, r2)
+            );
+
+            final Map<K, V> elements = Collections.unmodifiableMap(read);
+            final T errors = ops.createMap(failed.build());
+
+            return result.map(unit -> elements).setPartial(elements).mapError(e -> e + " missed input: " + errors);
+        }
+    }
+
+    public static <K, V> RelicsUnboundedMapCodec<K, V> unboundedMap(final Codec<K> keyCodec, final Codec<V> elementCodec) {
+        return new RelicsUnboundedMapCodec<>(keyCodec, elementCodec);
+    }
+}


### PR DESCRIPTION
ImmutableMap does not check for hashCode equality as an early rejection before checking Object equality.

String keys, which happen to also be the only key used in this project's codecs, are affected as their `equals` implementation takes linear time while their `hashCode` implementation is cached.